### PR TITLE
Ignoring all the *.iml files at .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 .DS_Store
 /build
 /captures
-/PaddeManager.iml
-/paddle-manager-android-app.iml
+*.iml


### PR DESCRIPTION
.iml files should not be added to the repository. This PR adds all of them to the .gitignore
